### PR TITLE
Remove/update tf specific version in setup

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     url="https://github.com/SUwonglab/CausalBGM",
     packages=setuptools.find_packages(),
     install_requires=[
-   'tensorflow==2.10.0',
+   'tensorflow',
    'pyyaml',
    'scikit-learn',
    'pandas',


### PR DESCRIPTION
Either remove or update the existing version not available in default pip/conda distributions.  I was able to run the CausalGBM class with the lates version of tf.